### PR TITLE
fix crossOrigin: 如果是 dataURL，或者 item 的 crossOrigin 属性为 false，则不设置 ima…

### DIFF
--- a/src/tool/SourceLoader.js
+++ b/src/tool/SourceLoader.js
@@ -27,7 +27,13 @@ var proto = {
   imageLoader: function(item) {
     var that = this;
     var image = new Image();
-    image.crossOrigin = '*';
+
+    if (!/^data:/.test(item.src) && item.crossOrigin !== false) {
+      image.crossOrigin = item.crossOrigin === true
+        ? '*'
+        : (item.crossOrigin || '*');
+    }
+
     image.onload = function() {
       var id = item.id;
       that.hash[id] = _.extend({}, item, {


### PR DESCRIPTION
1. 如果是 dataURL，不设置 crossOrigin 
2. 如果 item.crossOrigin 设为 false，不设置 crossOrigin
3. 如果 item.crossOrigin 设为 true，crossOrigin 为 *
4. crossOrigin 为 item.crossOrigin 或者 *
